### PR TITLE
Fix varint encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "varint": "^4.0.1"
   },
   "devDependencies": {
-    "aegir": "^8.1.1",
+    "aegir": "^9.1.2",
     "chai": "^3.5.0",
     "pre-commit": "^1.1.3"
   },

--- a/src/base-table.js
+++ b/src/base-table.js
@@ -1,31 +1,60 @@
 'use strict'
 
-const varint = require('varint')
-
 // spec and table at: https://github.com/multiformats/multicodec
-
-// TODO revisit all of these once https://github.com/multiformats/multicodec/pull/16 is merged
 
 exports = module.exports
 
 // Miscellaneous
-exports.raw = varintBuf(0)          // 0x00
+exports['raw'] = new Buffer('00', 'hex')
 
 // bases encodings
+exports['base1'] = new Buffer('01', 'hex')
+exports['base2'] = new Buffer('55', 'hex')
+exports['base8'] = new Buffer('07', 'hex')
+exports['base10'] = new Buffer('09', 'hex')
 
 // Serialization formats
-exports.protobuf = varintBuf(80)    // 0x50
-exports.cbor = varintBuf(81)        // 0x51
-exports.rlp = varintBuf(96)         // 0x60
+exports['protobuf'] = new Buffer('50', 'hex')
+exports['cbor'] = new Buffer('51', 'hex')
+exports['rlp'] = new Buffer('60', 'hex')
 
 // Multiformats
-exports.multicodec = varintBuf(64)  // 0x40
-exports.multihash = varintBuf(65)   // 0x41
-exports.multiaddr = varintBuf(66)   // 0x42
+exports['multicodec'] = new Buffer('30', 'hex')
+exports['multihash'] = new Buffer('31', 'hex')
+exports['multiaddr'] = new Buffer('32', 'hex')
+exports['multibase'] = new Buffer('33', 'hex')
 
 // multihashes
+exports['sha1'] = new Buffer('11', 'hex')
+exports['sha2-256'] = new Buffer('12', 'hex')
+exports['sha2-512'] = new Buffer('13', 'hex')
+exports['sha3-224'] = new Buffer('17', 'hex')
+exports['sha3-256'] = new Buffer('16', 'hex')
+exports['sha3-384'] = new Buffer('15', 'hex')
+exports['sha3-512'] = new Buffer('14', 'hex')
+exports['shake-128'] = new Buffer('18', 'hex')
+exports['shake-256'] = new Buffer('19', 'hex')
+exports['keccak-224'] = new Buffer('1a', 'hex')
+exports['keccak-256'] = new Buffer('1b', 'hex')
+exports['keccak-384'] = new Buffer('1c', 'hex')
+exports['keccak-512'] = new Buffer('1d', 'hex')
+exports['blake2b'] = new Buffer('40', 'hex')
+exports['blake2s'] = new Buffer('41', 'hex')
 
 // multiaddrs
+exports['ip4'] = new Buffer('04', 'hex')
+exports['ip6'] = new Buffer('29', 'hex')
+exports['tcp'] = new Buffer('06', 'hex')
+exports['udp'] = new Buffer('0111', 'hex')
+exports['dccp'] = new Buffer('21', 'hex')
+exports['sctp'] = new Buffer('84', 'hex')
+exports['udt'] = new Buffer('012d', 'hex')
+exports['utp'] = new Buffer('012e', 'hex')
+exports['ipfs'] = new Buffer('2a', 'hex')
+exports['http'] = new Buffer('01e0', 'hex')
+exports['https'] = new Buffer('01bb', 'hex')
+exports['ws'] = new Buffer('01dd', 'hex')
+exports['onion'] = new Buffer('01bc', 'hex')
 
 // archiving formats
 
@@ -41,7 +70,7 @@ exports['dag-cbor'] = new Buffer('71', 'hex')
 exports['eth-block'] = new Buffer('90', 'hex')
 exports['eth-tx'] = new Buffer('91', 'hex')
 exports['eth-account'] = new Buffer('92', 'hex')
-
-function varintBuf (n) {
-  return new Buffer(varint.encode(n))
-}
+exports['bitcoin-block'] = new Buffer('b0', 'hex')
+exports['bitcoin-tx'] = new Buffer('b1', 'hex')
+exports['stellar-block'] = new Buffer('d0', 'hex')
+exports['stellar-tx'] = new Buffer('d1', 'hex')

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,8 @@ exports.addPrefix = (multicodecStrOrCode, data) => {
       throw new Error('multicodec not recognized')
     }
   }
-  return Buffer.concat([pfx, data])
+  let encodedPrefix = new Buffer(varint.encode(bufferToNumber(pfx)))
+  return Buffer.concat([encodedPrefix, data])
 }
 
 exports.rmPrefix = (data) => {
@@ -27,7 +28,7 @@ exports.rmPrefix = (data) => {
 
 exports.getCodec = (prefixedData) => {
   const v = varint.decode(prefixedData)
-  const code = new Buffer(v.toString(16), 'hex')
+  const code = numberToBuffer(v)
   let codec
 
   Object.keys(table)
@@ -39,4 +40,16 @@ exports.getCodec = (prefixedData) => {
         })
 
   return codec
+}
+
+function bufferToNumber (buf) {
+  return parseInt(buf.toString('hex'), 16)
+}
+
+function numberToBuffer (num) {
+  let hexString = num.toString(16)
+  if (hexString.length % 2 === 1) {
+    hexString = '0' + hexString
+  }
+  return new Buffer(hexString, 'hex')
 }

--- a/src/name-table.js
+++ b/src/name-table.js
@@ -1,0 +1,12 @@
+'use strict'
+const baseTable = require('./base-table')
+
+// this creates a map for code as hexString -> codecName
+
+const nameTable = {}
+module.exports = nameTable
+
+for (let encodingName in baseTable) {
+  let code = baseTable[encodingName]
+  nameTable[code.toString('hex')] = encodingName
+}

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,29 @@
+'use strict'
+const varint = require('varint')
+
+module.exports = {
+  numberToBuffer,
+  bufferToNumber,
+  varintBufferEncode,
+  varintBufferDecode
+}
+
+function bufferToNumber (buf) {
+  return parseInt(buf.toString('hex'), 16)
+}
+
+function numberToBuffer (num) {
+  let hexString = num.toString(16)
+  if (hexString.length % 2 === 1) {
+    hexString = '0' + hexString
+  }
+  return new Buffer(hexString, 'hex')
+}
+
+function varintBufferEncode (input) {
+  return new Buffer(varint.encode(bufferToNumber(input)))
+}
+
+function varintBufferDecode (input) {
+  return numberToBuffer(varint.decode(input))
+}

--- a/src/varint-table.js
+++ b/src/varint-table.js
@@ -1,0 +1,13 @@
+'use strict'
+const baseTable = require('./base-table')
+const varintBufferEncode = require('./util').varintBufferEncode
+
+// this creates a map for codecName -> codeVarintBuffer
+
+const varintTable = {}
+module.exports = varintTable
+
+for (let encodingName in baseTable) {
+  let code = baseTable[encodingName]
+  varintTable[encodingName] = varintBufferEncode(code)
+}

--- a/test/multicodec.spec.js
+++ b/test/multicodec.spec.js
@@ -18,4 +18,11 @@ describe('multicodec', () => {
     expect(multicodec.getCodec(prefixedBuf)).to.equal('dag-pb')
     expect(buf).to.eql(multicodec.rmPrefix(prefixedBuf))
   })
+
+  it('add multibyte varint prefix (eth-block) through multicodec (string)', () => {
+    const buf = new Buffer('hey')
+    const prefixedBuf = multicodec.addPrefix('eth-block', buf)
+    expect(multicodec.getCodec(prefixedBuf)).to.equal('eth-block')
+    expect(buf).to.eql(multicodec.rmPrefix(prefixedBuf))
+  })
 })


### PR DESCRIPTION
This is a fix for encoding/decoding prefixes that are multi-byte after varint encoding e.g. (`0x90`)