### PR TITLE
feat: make adding a custom codec possible 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,3 +61,16 @@ exports.getCodec = (prefixedData) => {
   const codecName = codeToCodecName[code.toString('hex')]
   return codecName
 }
+
+/**
+ * Get the code as varint of a codec name.
+ * @param {string} codecName
+ * @returns {Buffer}
+ */
+exports.getCodeVarint = (codecName) => {
+  const code = codecNameToCodeVarint[codecName]
+  if (code === undefined) {
+    throw new Error('Codec `' + codecName + '` not found')
+  }
+  return code
+}

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,9 @@ exports.rmPrefix = (data) => {
 exports.getCodec = (prefixedData) => {
   const code = util.varintBufferDecode(prefixedData)
   const codecName = codeToCodecName[code.toString('hex')]
+  if (codecName === undefined) {
+    throw new Error('Code `0x' + code.toString('hex') + '` not found')
+  }
   return codecName
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -77,3 +77,14 @@ exports.getCodeVarint = (codecName) => {
   }
   return code
 }
+
+/**
+ * Add a new codec
+ * @param {string} name Name of the codec
+ * @param {Buffer} code The code of the codec
+ * @returns {void}
+ */
+exports.addCodec = (name, code) => {
+  codecNameToCodeVarint[name] = util.varintBufferEncode(code)
+  codeToCodecName[code.toString('hex')] = name
+}

--- a/test/multicodec.spec.js
+++ b/test/multicodec.spec.js
@@ -28,4 +28,17 @@ describe('multicodec', () => {
     expect(multicodec.getCodec(prefixedBuf)).to.equal('eth-block')
     expect(buf).to.eql(multicodec.rmPrefix(prefixedBuf))
   })
+
+  it('returns code via codec name', () => {
+    const code = multicodec.getCodeVarint('keccak-256')
+    expect(code).to.eql(Buffer.from('1b', 'hex'))
+  })
+
+  it('throws error on unknown codec name when getting the code', () => {
+    expect(() => {
+      multicodec.getCodeVarint('this-codec-doesnt-exist')
+    }).to.throw(
+      'Codec `this-codec-doesnt-exist` not found'
+    )
+  })
 })

--- a/test/multicodec.spec.js
+++ b/test/multicodec.spec.js
@@ -6,6 +6,7 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 const multicodec = require('../src')
+const util = require('../src/util')
 
 describe('multicodec', () => {
   it('add prefix through multicodec (string)', () => {
@@ -34,11 +35,41 @@ describe('multicodec', () => {
     expect(code).to.eql(Buffer.from('1b', 'hex'))
   })
 
+  it('works with custom codec when getting the code', () => {
+    const name = 'my-custom-codec1'
+    const code = Buffer.from('ffff', 'hex')
+    multicodec.addCodec(name, code)
+
+    const codeVarint = multicodec.getCodeVarint(name)
+    expect(util.varintBufferDecode(codeVarint)).to.deep.eql(code)
+  })
+
   it('throws error on unknown codec name when getting the code', () => {
     expect(() => {
       multicodec.getCodeVarint('this-codec-doesnt-exist')
     }).to.throw(
       'Codec `this-codec-doesnt-exist` not found'
+    )
+  })
+
+  it('works with custom codec when getting the codec', () => {
+    const name = 'my-custom-codec2'
+    const code = Buffer.from('ffff', 'hex')
+    multicodec.addCodec(name, code)
+
+    const buf = Buffer.from('hey')
+    const prefixedBuf = multicodec.addPrefix(name, buf)
+    expect(multicodec.getCodec(prefixedBuf)).to.eql(name)
+  })
+
+  it('throws error on unknown codec when adding as prefix', () => {
+    const name = 'this-codec-doesnt-exist'
+
+    const buf = Buffer.from('hey')
+    expect(() => {
+      multicodec.addPrefix(name, buf)
+    }).to.throw(
+      'multicodec not recognized'
     )
   })
 

--- a/test/multicodec.spec.js
+++ b/test/multicodec.spec.js
@@ -41,4 +41,16 @@ describe('multicodec', () => {
       'Codec `this-codec-doesnt-exist` not found'
     )
   })
+
+  it('throws error on unknown codec name when getting the codec', () => {
+    const code = Buffer.from('ffee', 'hex')
+
+    const buf = Buffer.from('hey')
+    const prefixedBuf = multicodec.addPrefix(code, buf)
+    expect(() => {
+      multicodec.getCodec(prefixedBuf)
+    }).to.throw(
+      'Code `0xffee` not found'
+    )
+  })
 })


### PR DESCRIPTION
With this change it is possible to add a custom codec via `addCodec()`.

Example:

    const name = 'my-custom-codec'
    const code = Buffer.from('ffff', 'hex')
    multicodec.addCodec(name, code)

I created self-contained commits, so it should be able to merge them with a rebase merge (as they are kind of separate things, but it made sense to bundle them in one PR as adding a custom codec is the actual goal.