### PR TITLE
Revert "feat: make adding a custom codec possible"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,14 +77,3 @@ exports.getCodeVarint = (codecName) => {
   }
   return code
 }
-
-/**
- * Add a new codec
- * @param {string} name Name of the codec
- * @param {Buffer} code The code of the codec
- * @returns {void}
- */
-exports.addCodec = (name, code) => {
-  codecNameToCodeVarint[name] = util.varintBufferEncode(code)
-  codeToCodecName[code.toString('hex')] = name
-}

--- a/test/multicodec.spec.js
+++ b/test/multicodec.spec.js
@@ -6,7 +6,6 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 const multicodec = require('../src')
-const util = require('../src/util')
 
 describe('multicodec', () => {
   it('add prefix through multicodec (string)', () => {
@@ -35,41 +34,11 @@ describe('multicodec', () => {
     expect(code).to.eql(Buffer.from('1b', 'hex'))
   })
 
-  it('works with custom codec when getting the code', () => {
-    const name = 'my-custom-codec1'
-    const code = Buffer.from('ffff', 'hex')
-    multicodec.addCodec(name, code)
-
-    const codeVarint = multicodec.getCodeVarint(name)
-    expect(util.varintBufferDecode(codeVarint)).to.deep.eql(code)
-  })
-
   it('throws error on unknown codec name when getting the code', () => {
     expect(() => {
       multicodec.getCodeVarint('this-codec-doesnt-exist')
     }).to.throw(
       'Codec `this-codec-doesnt-exist` not found'
-    )
-  })
-
-  it('works with custom codec when getting the codec', () => {
-    const name = 'my-custom-codec2'
-    const code = Buffer.from('ffff', 'hex')
-    multicodec.addCodec(name, code)
-
-    const buf = Buffer.from('hey')
-    const prefixedBuf = multicodec.addPrefix(name, buf)
-    expect(multicodec.getCodec(prefixedBuf)).to.eql(name)
-  })
-
-  it('throws error on unknown codec when adding as prefix', () => {
-    const name = 'this-codec-doesnt-exist'
-
-    const buf = Buffer.from('hey')
-    expect(() => {
-      multicodec.addPrefix(name, buf)
-    }).to.throw(
-      'multicodec not recognized'
     )
   })
 


### PR DESCRIPTION
This reverts commit c6ee55b20e44d14e14f040f8e0c04f72139f10fa.

BREAKING CHANGE: the `addCodec()` function is removed

The `addCodec()` function is removed as it doesn't work as expected.
Things break as soon as the module is loaded several times, which
can happen if dependencies require a different version.

Steps to reproduce this problem:

```console
$ mkdir addcodecbug
$ cd addcodecbug
$ npm install cids@0.5.7 multicodec@0.3.0
npm WARN saveError ENOENT: no such file or directory, open '/tmp/addcodecbug/package.json'
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN enoent ENOENT: no such file or directory, open '/tmp/addcodecbug/package.json'
npm WARN addcodecbug No description
npm WARN addcodecbug No repository field.
npm WARN addcodecbug No README data
npm WARN addcodecbug No license field.

+ multicodec@0.3.0
+ cids@0.5.7
added 10 packages from 35 contributors and audited 14 packages in 1.363s
found 0 vulnerabilities
$ cat > index.js <<'EOF'
// Uses multicodec v0.2.7
const CID = require('cids')
// Imports multicodec v0.3.0
const multicodec = require('multicodec')

multicodec.addCodec('my-codec', Buffer.from('5566', 'hex'))
// Works, the codec was added
console.log(multicodec.getCodeVarint('my-codec'))

const multihash = Buffer.from(
  '1220b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9',
  'hex')
const cid = new CID(1, 'my-codec', multihash)
console.log(cid)
// Fails as `my-codec` was only added to the multicodec module loaded by this
// file, and not the one loaded by `cids`.
console.log(cid.toBaseEncodedString())
EOF
$ node index.js
<Buffer e6 aa 01>
CID {
  codec: 'my-codec',
  version: 1,
  multihash:
   <Buffer 12 20 b9 4d 27 b9 93 4d 3e 08 a5 2e 52 d7 da 7d ab fa c4 84 ef e3 7a 53 80 ee 90 88 f7 ac e2 ef cd e9> }
/tmp/addcodecbug/node_modules/cids/node_modules/multicodec/src/index.js:76
    throw new Error('Codec `' + codecName + '` not found')
    ^

Error: Codec `my-codec` not found
    at Object.exports.getCodeVarint (/tmp/addcodecbug/node_modules/cids/node_modules/multicodec/src/index.js:76:11)
    at ClassIsWrapper.get buffer [as buffer] (/tmp/addcodecbug/node_modules/cids/src/index.js:131:22)
    at ClassIsWrapper.toBaseEncodedString (/tmp/addcodecbug/node_modules/cids/src/index.js:202:44)
    at Object.<anonymous> (/tmp/addcodecbug/index.js:17:17)
    at Module._compile (internal/modules/cjs/loader.js:702:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:713:10)
    at Module.load (internal/modules/cjs/loader.js:612:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:551:12)
    at Function.Module._load (internal/modules/cjs/loader.js:543:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:744:10)
```

Thanks @mikeal for telling me about this a long time ago. I finally found time to finally understanding the problem. For more information about module loading see https://medium.com/@lazlojuly/are-node-js-modules-singletons-764ae97519af.