### PR TITLE
feat: add method to convert codec names to numbers and back

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,28 @@ exports.getCodec = (prefixedData) => {
 }
 
 /**
+ * Get the name of the codec.
+ * @param {number} codec
+ * @returns {string}
+ */
+exports.getName = (codec) => {
+  return codeToCodecName[codec.toString(16)]
+}
+
+/**
+ * Get the code of the codec
+ * @param {string} name
+ * @returns {number}
+ */
+exports.getNumber = (name) => {
+  const code = codecNameToCodeVarint[name]
+  if (code === undefined) {
+    throw new Error('Codec `' + name + '` not found')
+  }
+  return util.varintBufferDecode(code)[0]
+}
+
+/**
  * Get the code of the prefixed data.
  * @param {Buffer} prefixedData
  * @returns {number}

--- a/test/multicodec.spec.js
+++ b/test/multicodec.spec.js
@@ -46,6 +46,16 @@ describe('multicodec', () => {
     expect(code).to.eql([0x1b])
   })
 
+  it('returns the codec name from code', () => {
+    expect(multicodec.getName(144)).to.eql('eth-block')
+    expect(multicodec.getName(112)).to.eql('dag-pb')
+  })
+
+  it('returns the codec number from name', () => {
+    expect(multicodec.getNumber('eth-block')).to.eql(144)
+    expect(multicodec.getNumber('dag-pb')).to.eql(112)
+  })
+
   it('throws error on unknown codec name when getting the code', () => {
     expect(() => {
       multicodec.getCodeVarint('this-codec-doesnt-exist')


### PR DESCRIPTION
Since https://github.com/ipld/js-ipld/commit/108aef0a0e1954cb4481380a26c4d9e00854607d codec names have started being passed around by `js-ipld` as numbers instead of strings.
    
From a DX perspective it's still quite nice to use human-readable strings instead of numbers but at some point you have to convert between them so this PR adds methods to get a codec name based on a number and a number based on a name.