### PR TITLE
docs: add space so pasting doesn't escape '|'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Updating the lookup table is done with a script. The source of truth is the
 [multicodec default table](https://github.com/multiformats/multicodec/blob/master/table.csv).
 Update the table with running:
 
-    curl -X GET https://raw.githubusercontent.com/multiformats/multicodec/master/table.csv|./tools/update-table.py
+    curl -X GET https://raw.githubusercontent.com/multiformats/multicodec/master/table.csv | ./tools/update-table.py
 
 ## Contribute
 


### PR DESCRIPTION
License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>