### PR TITLE
Add ZeroNet, JSON and MessagePack support

### DIFF
--- a/src/base-table.js
+++ b/src/base-table.js
@@ -8,6 +8,8 @@ exports['protobuf'] = Buffer.from('50', 'hex')
 exports['cbor'] = Buffer.from('51', 'hex')
 exports['rlp'] = Buffer.from('60', 'hex')
 exports['bencode'] = Buffer.from('63', 'hex')
+exports['json'] = Buffer.from('0200', 'hex')
+exports['messagepack'] = Buffer.from('0201', 'hex')
 
 // multiformat
 exports['multicodec'] = Buffer.from('30', 'hex')
@@ -389,7 +391,6 @@ exports['ws'] = Buffer.from('01dd', 'hex')
 exports['wss'] = Buffer.from('01de', 'hex')
 exports['p2p-websocket-star'] = Buffer.from('01df', 'hex')
 exports['http'] = Buffer.from('01e0', 'hex')
-exports['zeronet'] = Buffer.from('1000', 'hex')
 
 // ipld
 exports['raw'] = Buffer.from('55', 'hex')
@@ -431,6 +432,7 @@ exports['ipld-ns'] = Buffer.from('e2', 'hex')
 exports['ipfs-ns'] = Buffer.from('e3', 'hex')
 exports['swarm-ns'] = Buffer.from('e4', 'hex')
 exports['ipns-ns'] = Buffer.from('e5', 'hex')
+exports['zeronet'] = Buffer.from('e6', 'hex')
 
 // key
 exports['ed25519-pub'] = Buffer.from('ed', 'hex')

--- a/src/base-table.js
+++ b/src/base-table.js
@@ -389,6 +389,7 @@ exports['ws'] = Buffer.from('01dd', 'hex')
 exports['wss'] = Buffer.from('01de', 'hex')
 exports['p2p-websocket-star'] = Buffer.from('01df', 'hex')
 exports['http'] = Buffer.from('01e0', 'hex')
+exports['zeronet'] = Buffer.from('1000', 'hex')
 
 // ipld
 exports['raw'] = Buffer.from('55', 'hex')

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,8 @@ module.exports = Object.freeze({
   CBOR: 0x51,
   RLP: 0x60,
   BENCODE: 0x63,
+  JSON: 0x0200,
+  MESSAGEPACK: 0x0201,
 
   // multiformat
   MULTICODEC: 0x30,
@@ -390,7 +392,6 @@ module.exports = Object.freeze({
   WSS: 0x01de,
   P2P_WEBSOCKET_STAR: 0x01df,
   HTTP: 0x01e0,
-  ZERONET: 0x1000,
 
   // ipld
   RAW: 0x55,
@@ -432,6 +433,7 @@ module.exports = Object.freeze({
   IPFS_NS: 0xe3,
   SWARM_NS: 0xe4,
   IPNS_NS: 0xe5,
+  ZERONET: 0xe6,
 
   // key
   ED25519_PUB: 0xed,

--- a/src/constants.js
+++ b/src/constants.js
@@ -390,6 +390,7 @@ module.exports = Object.freeze({
   WSS: 0x01de,
   P2P_WEBSOCKET_STAR: 0x01df,
   HTTP: 0x01e0,
+  ZERONET: 0x1000,
 
   // ipld
   RAW: 0x55,

--- a/src/print.js
+++ b/src/print.js
@@ -389,6 +389,7 @@ module.exports = Object.freeze({
   0x01de: 'wss',
   0x01df: 'p2p-websocket-star',
   0x01e0: 'http',
+  0x1000: 'zeronet',
 
   // ipld
   0x55: 'raw',

--- a/src/print.js
+++ b/src/print.js
@@ -9,6 +9,8 @@ module.exports = Object.freeze({
   0x51: 'cbor',
   0x60: 'rlp',
   0x63: 'bencode',
+  0x0200: 'json',
+  0x0201: 'messagepack',
 
   // multiformat
   0x30: 'multicodec',
@@ -389,7 +391,6 @@ module.exports = Object.freeze({
   0x01de: 'wss',
   0x01df: 'p2p-websocket-star',
   0x01e0: 'http',
-  0x1000: 'zeronet',
 
   // ipld
   0x55: 'raw',
@@ -431,6 +432,7 @@ module.exports = Object.freeze({
   0xe3: 'ipfs-ns',
   0xe4: 'swarm-ns',
   0xe5: 'ipns-ns',
+  0xe6: 'zeronet',
 
   // key
   0xed: 'ed25519-pub',


### PR DESCRIPTION
Add support for [ZeroNet](https://zeronet.io/) site address. ZeroNet uses old-style Bitcoin addresses as site addresses.

PR also includes other codecs that are included in the official table but still not used in this project (JSON, MessagePack).

Also see multiformats/multicodec#140.