### PR TITLE
chore: add libp2p peer record

### DIFF
--- a/src/base-table.json
+++ b/src/base-table.json
@@ -99,6 +99,7 @@
   "http": 480,
   "json": 512,
   "messagepack": 513,
+  "libp2p-peer-record": 769,
   "x11": 4352,
   "blake2b-8": 45569,
   "blake2b-16": 45570,


### PR DESCRIPTION
We are currently working in adding support for libp2p signed records in `js-libp2p`.
In the context of [multiformats/multicodec#157](https://github.com/multiformats/multicodec/pull/157), this PR adds a multicodec for it.