### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# js-multicodec
+# js-multicodec <!-- omit in toc -->
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](https://protocol.ai)
 [![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](https://github.com/multiformats/multiformats)
@@ -9,14 +9,16 @@
 
 > JavaScript implementation of the multicodec specification
 
-## Lead Maintainer
+## Lead Maintainer <!-- omit in toc -->
 
 [Henrique Dias](http://github.com/hacdias)
 
-## Table of Contents
+## Table of Contents <!-- omit in toc -->
 
 - [Install](#install)
 - [Usage](#usage)
+  - [Example](#example)
+  - [API](#api)
 - [Updating the lookup table](#updating-the-lookup-table)
 - [Contribute](#contribute)
 - [License](#license)

--- a/example.js
+++ b/example.js
@@ -2,7 +2,7 @@
 
 const multicodec = require('multicodec')
 
-const prefixedProtobuf = multicodec.addPrefix('protobuf', Buffer.from('some protobuf code'))
+const prefixedProtobuf = multicodec.addPrefix('protobuf', new TextEncoder().encode('some protobuf code'))
 
 // eslint-disable-next-line no-console
 console.log(prefixedProtobuf)

--- a/package.json
+++ b/package.json
@@ -41,14 +41,12 @@
   },
   "homepage": "https://github.com/multiformats/js-multicodec#readme",
   "dependencies": {
-    "buffer": "^5.6.0",
+    "uint8arrays": "0.0.2",
     "varint": "^5.0.0"
   },
   "devDependencies": {
     "aegir": "^23.0.0",
     "bent": "^7.3.4",
-    "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1",
     "pre-push": "~0.1.1"
   },
   "contributors": [

--- a/src/util.js
+++ b/src/util.js
@@ -1,35 +1,37 @@
 'use strict'
+
 const varint = require('varint')
-const { Buffer } = require('buffer')
+const uint8ArrayToString = require('uint8arrays/to-string')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 module.exports = {
-  numberToBuffer,
-  bufferToNumber,
-  varintBufferEncode,
-  varintBufferDecode,
+  numberToUint8Array,
+  uint8ArrayToNumber,
+  varintUint8ArrayEncode,
+  varintUint8ArrayDecode,
   varintEncode
 }
 
-function bufferToNumber (buf) {
-  return parseInt(buf.toString('hex'), 16)
+function uint8ArrayToNumber (buf) {
+  return parseInt(uint8ArrayToString(buf, 'base16'), 16)
 }
 
-function numberToBuffer (num) {
+function numberToUint8Array (num) {
   let hexString = num.toString(16)
   if (hexString.length % 2 === 1) {
     hexString = '0' + hexString
   }
-  return Buffer.from(hexString, 'hex')
+  return uint8ArrayFromString(hexString, 'base16')
 }
 
-function varintBufferEncode (input) {
-  return Buffer.from(varint.encode(bufferToNumber(input)))
+function varintUint8ArrayEncode (input) {
+  return Uint8Array.from(varint.encode(uint8ArrayToNumber(input)))
 }
 
-function varintBufferDecode (input) {
-  return numberToBuffer(varint.decode(input))
+function varintUint8ArrayDecode (input) {
+  return numberToUint8Array(varint.decode(input))
 }
 
 function varintEncode (num) {
-  return Buffer.from(varint.encode(num))
+  return Uint8Array.from(varint.encode(num))
 }

--- a/src/varint-table.js
+++ b/src/varint-table.js
@@ -3,7 +3,7 @@
 const baseTable = require('./base-table.json')
 const varintEncode = require('./util').varintEncode
 
-// map for codecName -> codeVarintBuffer
+// map for codecName -> codeVarintUint8Array
 const varintTable = {}
 
 for (const encodingName in baseTable) {

--- a/test/multicodec.spec.js
+++ b/test/multicodec.spec.js
@@ -1,29 +1,27 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const multicodec = require('../src')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('multicodec', () => {
   it('add prefix through multicodec (string)', () => {
-    const buf = Buffer.from('hey')
+    const buf = uint8ArrayFromString('hey')
     const prefixedBuf = multicodec.addPrefix('protobuf', buf)
     expect(multicodec.getCodec(prefixedBuf)).to.equal('protobuf')
     expect(buf).to.eql(multicodec.rmPrefix(prefixedBuf))
   })
 
   it('add prefix through code (code)', () => {
-    const buf = Buffer.from('hey')
-    const prefixedBuf = multicodec.addPrefix(Buffer.from('70', 'hex'), buf)
+    const buf = uint8ArrayFromString('hey')
+    const prefixedBuf = multicodec.addPrefix(uint8ArrayFromString('70', 'base16'), buf)
     expect(multicodec.getCodec(prefixedBuf)).to.equal('dag-pb')
     expect(buf).to.eql(multicodec.rmPrefix(prefixedBuf))
   })
 
   it('add multibyte varint prefix (eth-block) through multicodec (string)', () => {
-    const buf = Buffer.from('hey')
+    const buf = uint8ArrayFromString('hey')
     const prefixedBuf = multicodec.addPrefix('eth-block', buf)
     expect(multicodec.getCodec(prefixedBuf)).to.equal('eth-block')
     expect(buf).to.eql(multicodec.rmPrefix(prefixedBuf))
@@ -31,11 +29,11 @@ describe('multicodec', () => {
 
   it('returns code via codec name', () => {
     const code = multicodec.getCodeVarint('keccak-256')
-    expect(code).to.eql(Buffer.from('1b', 'hex'))
+    expect(code).to.eql(uint8ArrayFromString('1b', 'base16'))
   })
 
   it('returns code from prefixed data', () => {
-    const buf = Buffer.from('hey')
+    const buf = uint8ArrayFromString('hey')
     const prefixedBuf = multicodec.addPrefix('dag-cbor', buf)
     const code = multicodec.getCode(prefixedBuf)
     expect(code).to.eql(multicodec.DAG_CBOR)
@@ -92,9 +90,9 @@ describe('multicodec', () => {
   })
 
   it('throws error on unknown codec name when getting the codec', () => {
-    const code = Buffer.from('ffee', 'hex')
+    const code = uint8ArrayFromString('ffee', 'base16')
 
-    const buf = Buffer.from('hey')
+    const buf = uint8ArrayFromString('hey')
     const prefixedBuf = multicodec.addPrefix(code, buf)
     expect(() => {
       multicodec.getCodec(prefixedBuf)


### PR DESCRIPTION
All usages of node `Buffer`s have been replaced with `Uint8Array`s.

BREAKING CHANGES:

- Where node `Buffer`s were returned, they are now `Uint8Array`s