### PR TITLE
fix: getNumber varint decode bug 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ exports.getNumber = (name) => {
   if (code === undefined) {
     throw new Error('Codec `' + name + '` not found')
   }
-  return util.varintUint8ArrayDecode(code)[0]
+  return varint.decode(code)
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -8,7 +8,6 @@ module.exports = {
   numberToUint8Array,
   uint8ArrayToNumber,
   varintUint8ArrayEncode,
-  varintUint8ArrayDecode,
   varintEncode
 }
 
@@ -26,10 +25,6 @@ function numberToUint8Array (num) {
 
 function varintUint8ArrayEncode (input) {
   return Uint8Array.from(varint.encode(uint8ArrayToNumber(input)))
-}
-
-function varintUint8ArrayDecode (input) {
-  return numberToUint8Array(varint.decode(input))
 }
 
 function varintEncode (num) {

--- a/test/multicodec.spec.js
+++ b/test/multicodec.spec.js
@@ -4,6 +4,7 @@
 const { expect } = require('aegir/utils/chai')
 const multicodec = require('../src')
 const uint8ArrayFromString = require('uint8arrays/from-string')
+const baseTable = require('../src/base-table.json')
 
 describe('multicodec', () => {
   it('add prefix through multicodec (string)', () => {
@@ -53,9 +54,13 @@ describe('multicodec', () => {
   it('returns the codec number from name', () => {
     expect(multicodec.getNumber('eth-block')).to.eql(144)
     expect(multicodec.getNumber('dag-pb')).to.eql(112)
-    // NOTE vmx 2019-09019: Uncomment once
-    // https://github.com/multiformats/js-multicodec/issues/50 is fixed
-    // expect(multicodec.getNumber('blake2b-8')).to.eql(0xb201)
+    expect(multicodec.getNumber('blake2b-8')).to.eql(0xb201)
+  })
+
+  it('returns all codec numbers from names', () => {
+    for (const name in baseTable) {
+      expect(multicodec.getNumber(name)).to.eql(baseTable[name])
+    }
   })
 
   it('returns the codec number from constant', () => {


### PR DESCRIPTION
This hopefully fixes #50 by removing the call to numberToUint8Array() in varintUint8ArrayDecode.
It returned a wrongly encoded Uint8Array that had 1 as it's first byte, so all codec above 256 could not be resolved.