### PR TITLE
BREAKING: move constants out of main export

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ const prefixedProtobuf = multicodec.addPrefix('protobuf', protobufBuffer)
 // prefixedProtobuf 0x50...
 
 // The multicodec codec values can be accessed directly:
-console.log(multicodec.DAG_CBOR)
+console.log(multicodec.codecs.DAG_CBOR)
 // 113
 
 // To get the string representation of a codec, e.g. for error messages:

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ function getVarint (code) {
 }
 
 // Make the constants top-level constants
-const constants = require('./constants')
+const codecs = require('./constants')
 
 // Human friendly names for printing, e.g. in error messages
 const print = require('./print')
@@ -142,5 +142,5 @@ module.exports = {
   getCodeVarint,
   getVarint,
   print,
-  ...constants
+  codecs
 }

--- a/test/multicodec.spec.js
+++ b/test/multicodec.spec.js
@@ -40,11 +40,11 @@ describe('multicodec', () => {
     const buf = uint8ArrayFromString('hey')
     const prefixedBuf = multicodec.addPrefix('dag-cbor', buf)
     const code = multicodec.getCode(prefixedBuf)
-    expect(code).to.eql(multicodec.DAG_CBOR)
+    expect(code).to.eql(multicodec.codecs.DAG_CBOR)
   })
 
   it('returns varint from code', () => {
-    const code = multicodec.getVarint(multicodec.KECCAK_256)
+    const code = multicodec.getVarint(multicodec.codecs.KECCAK_256)
     expect(code).to.eql([0x1b])
   })
 
@@ -67,9 +67,9 @@ describe('multicodec', () => {
   })
 
   it('returns the codec number from constant', () => {
-    expect(multicodec.ETH_BLOCK).to.eql(144)
-    expect(multicodec.DAG_PB).to.eql(112)
-    expect(multicodec.BLAKE2B_8).to.eql(0xb201)
+    expect(multicodec.codecs.ETH_BLOCK).to.eql(144)
+    expect(multicodec.codecs.DAG_PB).to.eql(112)
+    expect(multicodec.codecs.BLAKE2B_8).to.eql(0xb201)
   })
 
   it('returns the name from codec number', () => {
@@ -78,10 +78,10 @@ describe('multicodec', () => {
     expect(multicodec.print[0x0111]).to.eql('udp')
     expect(multicodec.print[0xb201]).to.eql('blake2b-8')
 
-    expect(multicodec.print[multicodec.ETH_BLOCK]).to.eql('eth-block')
-    expect(multicodec.print[multicodec.DAG_PB]).to.eql('dag-pb')
-    expect(multicodec.print[multicodec.UDP]).to.eql('udp')
-    expect(multicodec.print[multicodec.BLAKE2B_8]).to.eql('blake2b-8')
+    expect(multicodec.print[multicodec.codecs.ETH_BLOCK]).to.eql('eth-block')
+    expect(multicodec.print[multicodec.codecs.DAG_PB]).to.eql('dag-pb')
+    expect(multicodec.print[multicodec.codecs.UDP]).to.eql('udp')
+    expect(multicodec.print[multicodec.codecs.BLAKE2B_8]).to.eql('blake2b-8')
   })
 
   it('returns p2p when 0x01a5 is used', () => {


### PR DESCRIPTION
Exporting all the codecs constants makes the documentation (and the package) very cluttered. Look at this [(you can barely find the functions in the docs)](https://multiformats.github.io/js-multicodec/modules/__multicodec_.html):

<img width="1440" alt="Screen Shot 2020-12-11 at 18 01 24" src="https://user-images.githubusercontent.com/5447088/101932318-82e2ba80-3bd2-11eb-8d87-a81ba0012027.png">

With this, you can access `multicodecs.codecs.YOUR_MARVELOUS_CODEC`.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>