### PR TITLE
chore: update uint8arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "homepage": "https://github.com/multiformats/js-multicodec#readme",
   "dependencies": {
-    "uint8arrays": "^2.1.3",
+    "uint8arrays": "^2.1.5",
     "varint": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This should not be needed, and I am clueless on why it is needed. However, with the current shipped version using `skypack` https://codepen.io/vascosantos/pen/mdWZmWq?editors=0011 we get:

![image](https://user-images.githubusercontent.com/7295071/123091277-6fd66000-d429-11eb-8241-4814bc504565.png)

which by going into the sources loaded we can see that it is pulling the old `uint8arrays@2.1.3` instead of `uint8arrays@2.1.5`

Related to https://github.com/vasco-santos/ipfs-car/issues/27